### PR TITLE
disable top-level comment validation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,6 @@ Metrics/LineLength:
 
 Metrics/BlockLength:
   Max: 300
+
+Documentation:
+  Enabled: false


### PR DESCRIPTION
# Trello Ticket: 
No Trello ticket. See Slack thread on ucberkeleyjuly from 11/6/19.

# Description:
Disabling the Rubocop top-level comment validation that is enforcing a comment to be added to each file created by Rails.

# Documentation Referenced:
https://stackoverflow.com/questions/36457669/top-level-class-documentation