### PR TITLE
Build chessboard

### DIFF
--- a/app/assets/stylesheets/master.scss
+++ b/app/assets/stylesheets/master.scss
@@ -1,1 +1,63 @@
 @import "bootstrap";
+
+.top-nav {
+  background-color: white;
+  border-bottom-color: #edeeee;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+  height: 70px;
+  padding-top: 15px;
+}
+
+.top-nav .add a {
+  font-weight: bold;
+  color: #125688;
+  font-size: 16px;
+  padding-left: 8px;
+}
+
+.top-nav .add {
+  margin-top: 20px;
+}
+
+.brand {
+  color: #31A01C;
+  font-size: 30px;
+  font-family: 'Pacifico', cursive;
+}
+
+#chessboard {
+    width: 690px;
+    height: 690px;
+    border: 25px solid #333;
+}
+
+table td {
+    width: 90px;
+    height: 90px;
+    vertical-align: middle;
+    text-align: center;
+    padding: 2px 0 5px 0;
+}
+
+.white {
+    float: left;
+    width: 80px;
+    height: 80px;
+    background-color: #fff;
+    font-size:50px;
+    text-align:center;
+    display: table-cell;
+    vertical-align:middle;
+}
+
+.black {
+    float: left;
+    width: 80px;
+    height: 80px;
+    background-color: #999;
+      font-size:50px;
+    text-align:center;
+    display: table-cell;
+    vertical-align:middle;
+}

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -4,7 +4,10 @@ class GamesController < ApplicationController
 
   def create; end
 
-  def show; end
+  def show
+    @game = Game.find_by_id(params[:id])
+    return render_not_found if @game.blank?
+  end
 
   def index; end
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,0 +1,20 @@
+  <div class="col-10 center offset-1">
+    <table id="chessboard">
+      <tbody>
+        <% [8, 7, 6, 5, 4, 3, 2, 1].each do |row| %>
+          <tr>
+            <% (1..8).each do |col| %>
+              <td
+              <% if (col + row).odd? %>
+                class="white"
+              <% else %>
+                class="black"
+              <% end %>
+              >
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,15 +7,30 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <link href='https://fonts.googleapis.com/css?family=Pacifico' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Josefin+Sans:400,100,300,600,700' rel='stylesheet' type='text/css'>
   </head>
 
   <body>
-  <% if notice.present? %>
-    <p class="alert alert-info"><%= notice %></p>
-  <% end %>
-  <% if alert.present? %>
-    <p class="alert alert-danger"><%= alert %></p>
-  <% end %>
+    <div class="top-nav">
+      <div class="col-10 offset-1 col-sm-8 offset-sm-2 col-md-6 offset-md-3">
+        <div class="brand  float-left">
+          <%= link_to 'Not-just-chess', root_path, class: 'brand' %>
+        </div>
+        <div class="add float-right">
+          <% if current_user %>
+            Welcome, <%= current_user.email %>
+            <%= link_to "New Post", new_game_path %>
+            <%= link_to "Sign out", destroy_user_session_path, method: :delete %>
+          <% else %>
+            <%= link_to "Sign In", new_user_session_path %>
+            <%= link_to "Sign Up", new_user_registration_path %>
+          <% end %>
+        </div>
+
+      </div>
+      <br class="clear-fix" />
+    </div>
 
     <%= yield %>
   </body>

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -6,5 +6,10 @@ RSpec.describe GamesController, type: :controller do
       get :index
       expect(response).to have_http_status(:success)
     end
+
+    describe 'games#show action' do
+      it 'should successfully show the page if a game is found' do
+      end
+    end
   end
 end

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -6,10 +6,15 @@ RSpec.describe GamesController, type: :controller do
       get :index
       expect(response).to have_http_status(:success)
     end
+  end
 
-    describe 'games#show action' do
-      it 'should successfully show the page if a game is found' do
-      end
+  describe 'games#show action' do
+    it 'should successfully show the page if a game is found' do
+      game = FactoryBot.create(
+        :game
+      )
+      get :show, params: { id: game.id }
+      expect(response).to have_http_status(:success)
     end
   end
 end


### PR DESCRIPTION
# Trello Ticket: 
https://trello.com/c/mmtN1TTi/12-build-view-for-the-chess-board-draw-a-chess-board

# Description:
Need to add a 'empty' chessboard to the games#show page. The board should be an 8x8 grid of alternating white/black just like a chess board (bottom left square should be black).
The directions stated to have the chessboard on games#show page, so you have to manually navigate to **http://localhost:3030/games/1** to view the chessboard. I do not believe we have made any changes to games#index yet.

Primary Files changed:
- app/views/games/show.html.erb to generate the empty chessboard
- app/stylesheets/master.scss to style the black/white squares
- spec/controllers/games_controller_spec.rb to add a test for the games#show action

I also added in a temporary top nav bar and referenced our Grammable code to have the App Name, Sign In and Sign out links.

Thank you to Wilson for reviewing the code and helping me set up the rspec test!

# Documentation Referenced:
There were several examples to generate the chessboard available online, so I ended up referencing the one that made most sense to me. 
https://codepen.io/acoustichead/pen/Jompap
https://www.theodinproject.com/courses/ruby-programming/lessons/ruby-final-project

