### PR TITLE
Pawn promotion

### DIFF
--- a/app/assets/javascripts/chess_pieces.coffee
+++ b/app/assets/javascripts/chess_pieces.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/chess_pieces.js
+++ b/app/assets/javascripts/chess_pieces.js
@@ -8,7 +8,6 @@ $(document).ready(function() {
   });
 
   function canPromote() {
-    console.log(this);
     if (this.type === "Pawn" && this.y_position == 8 || this.y_position == 1)  
       return true;
     else
@@ -66,7 +65,6 @@ $(document).ready(function() {
           document.getElementById("pawnPromoteModal").style.display = "block"
           $('#promote_container button').click(function(e) {
           document.getElementById("pawnPromoteModal").style.display = "none"
-          console.log(chooseCode(update_piece))
             $.ajax({
                 type: 'PATCH',
                 url: '/chess_pieces/' + update_piece.id,

--- a/app/assets/javascripts/chess_pieces.js
+++ b/app/assets/javascripts/chess_pieces.js
@@ -1,0 +1,117 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.
+
+$(document).ready(function() {
+  $('.piece').draggable({
+      snap: '.droppable',
+      revert: 'invalid'
+  });
+
+  function canPromote() {
+    let piece = $(this)
+    if (piece.data('piece-type') === "Pawn" && piece.data('y_position') === "8" || piece.data('y_position') === "1")  
+      return true
+    else
+      return false;
+  };
+
+// BELOW HERE IS THE PROMOTION MODAL JS  
+  var pawnPromoteModal = document.getElementById("pawnPromoteModal");
+
+  // Get the button that opens the modal
+  var btn = document.getElementById("myBtn");
+
+  var queenBtn = document.getElementById("queenBtn")
+
+  // Get the <span> element that closes the modal
+  var span = document.getElementsByClassName("close")[0];
+
+  // When the user clicks on the button, open the modal
+  btn.onclick = function() {
+    document.getElementById("pawnPromoteModal").style.display = "block";
+  }
+
+  queenBtn.onclick = function() {
+    console.log(queenBtn.innerHTML)
+  }
+
+  // When the user clicks on <span> (x), close the modal
+  span.onclick = function() {
+    pawnPromoteModal.style.display = "none";
+  }
+
+  // When the user clicks anywhere outside of the modal, close it
+  window.onclick = function(event) {
+    if (event.target == pawnPromoteModal) {
+      pawnPromoteModal.style.display = "none";
+    }
+  }
+// above here is the promotion modal JS
+
+  $('.droppable').droppable({
+      drop: function(event, ui) {
+          let piece = ui.draggable
+          let destination_square = $(this);
+          console.log($(this));
+          var update_piece = {
+              id: piece.data('piece-id'),
+              game_id: piece.data('game-id'),
+              x_position: destination_square.data('x_position'),
+              y_position: destination_square.data('y_position')
+          }
+
+          if (update_piece.canPromote) { 
+              document.getElementById("pawnPromoteModal").style.display = "block"
+              $('modalEx submit').onSubmit(function(e) {
+                  $.ajax({
+                      type: 'PATCH',
+                      url: '/chess_pieces/' + update_piece.id,
+                      beforeSend: function(xhr) { xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content')) },
+                      dataType: 'json',
+                      data: {
+                          id: update_piece.id,
+                          game_id: update_piece.game_id,
+                          x_position: update_piece.x_position,
+                          y_position: update_piece.y_position,
+                          type: $('pawnPromoteModal form radio-btn active').value
+                      },
+                      success: function(data) {
+                          destination_square.empty();
+                          location.reload(true);
+                      }
+                  })
+              })
+          }
+
+          $.ajax({
+              type: 'PATCH',
+              url: '/chess_pieces/' + update_piece.id,
+              beforeSend: function(xhr) { xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content')) },
+              dataType: 'json',
+              data: {
+                  id: update_piece.id,
+                  game_id: update_piece.game_id,
+                  x_position: update_piece.x_position,
+                  y_position: update_piece.y_position,
+              },
+              success: function(data) {
+                  destination_square.empty();
+                  location.reload(true);
+              }
+          });
+      }
+  });
+});
+
+
+
+
+
+  //def pawn_promotion(destination)
+    //if self.type(Pawn) && y_position == 8 || y_position == 1
+      //launch_modal
+      //update_attributes(type: "#{@promotion_type}", )
+    //end
+  //end
+
+

--- a/app/assets/javascripts/chess_pieces.js
+++ b/app/assets/javascripts/chess_pieces.js
@@ -8,9 +8,9 @@ $(document).ready(function() {
   });
 
   function canPromote() {
-    let piece = $(this)
-    if (piece.data('piece-type') === "Pawn" && piece.data('y_position') === "8" || piece.data('y_position') === "1")  
-      return true
+    console.log(this);
+    if (this.type === "Pawn" && this.y_position == 8 || this.y_position == 1)  
+      return true;
     else
       return false;
   };
@@ -24,7 +24,7 @@ $(document).ready(function() {
   var queenBtn = document.getElementById("queenBtn")
 
   // Get the <span> element that closes the modal
-  var span = document.getElementsByClassName("close")[0];
+  var span = document.getElementsByClassName("close");
 
   // When the user clicks on the button, open the modal
   btn.onclick = function() {
@@ -49,40 +49,44 @@ $(document).ready(function() {
 // above here is the promotion modal JS
 
   $('.droppable').droppable({
-      drop: function(event, ui) {
-          let piece = ui.draggable
-          let destination_square = $(this);
-          console.log($(this));
-          var update_piece = {
-              id: piece.data('piece-id'),
-              game_id: piece.data('game-id'),
-              x_position: destination_square.data('x_position'),
-              y_position: destination_square.data('y_position')
-          }
-
-          if (update_piece.canPromote) { 
-              document.getElementById("pawnPromoteModal").style.display = "block"
-              $('modalEx submit').onSubmit(function(e) {
-                  $.ajax({
-                      type: 'PATCH',
-                      url: '/chess_pieces/' + update_piece.id,
-                      beforeSend: function(xhr) { xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content')) },
-                      dataType: 'json',
-                      data: {
-                          id: update_piece.id,
-                          game_id: update_piece.game_id,
-                          x_position: update_piece.x_position,
-                          y_position: update_piece.y_position,
-                          type: $('pawnPromoteModal form radio-btn active').value
-                      },
-                      success: function(data) {
-                          destination_square.empty();
-                          location.reload(true);
-                      }
-                  })
-              })
-          }
-
+    drop: function(event, ui) {
+        let piece = ui.draggable
+        let destination_square = $(this);
+        var update_piece = {
+            id: piece.data('piece-id'),
+            game_id: piece.data('game-id'),
+            x_position: destination_square.data('x_position'),
+            y_position: destination_square.data('y_position'),
+            type: piece.data('piece-type'),
+            color: piece.data('color'),
+            canPromote: canPromote
+        }
+        console.log(update_piece)
+        if (update_piece.canPromote()) { 
+          document.getElementById("pawnPromoteModal").style.display = "block"
+          $('#promote_container button').click(function(e) {
+          document.getElementById("pawnPromoteModal").style.display = "none"
+          console.log(chooseCode(update_piece))
+            $.ajax({
+                type: 'PATCH',
+                url: '/chess_pieces/' + update_piece.id,
+                beforeSend: function(xhr) { xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content')) },
+                dataType: 'json',
+                data: {
+                    id: update_piece.id,
+                    game_id: update_piece.game_id,
+                    x_position: update_piece.x_position,
+                    y_position: update_piece.y_position,
+                    type: $(e.target).val(),
+                    htmlcode: chooseCode(update_piece.color, $(e.target).val())
+                },
+                success: function(data) {
+                    destination_square.empty();
+                    // location.reload(true);
+                }
+            })
+          })
+        } else {
           $.ajax({
               type: 'PATCH',
               url: '/chess_pieces/' + update_piece.id,
@@ -96,22 +100,46 @@ $(document).ready(function() {
               },
               success: function(data) {
                   destination_square.empty();
-                  location.reload(true);
+                  // location.reload(true);
               }
           });
+        }
       }
   });
+
 });
 
 
-
-
-
-  //def pawn_promotion(destination)
-    //if self.type(Pawn) && y_position == 8 || y_position == 1
-      //launch_modal
-      //update_attributes(type: "#{@promotion_type}", )
-    //end
-  //end
-
-
+function chooseCode(color, type) {
+  if (color === true){ 
+    switch(type) {
+      case 'Queen':
+        return '&#9813;';
+        break;
+      case 'Bishop':
+        return '&#9815;';
+        break;
+      case 'Rook':
+        return '&#9814;';
+        break;
+      case 'Knight':
+        return '&#9816;';
+        break;
+    }
+  } else {
+    switch(type) {
+      case 'Queen':
+        return '&#9819';
+        break;
+      case 'Bishop':
+        return '&#9821;';
+        break;
+      case 'Rook':
+        return '&#9820;';
+        break;
+      case 'Knight':
+        return '&#9822;';
+        break;
+    }
+  }
+}

--- a/app/assets/javascripts/chess_pieces.js
+++ b/app/assets/javascripts/chess_pieces.js
@@ -82,7 +82,7 @@ $(document).ready(function() {
                 },
                 success: function(data) {
                     destination_square.empty();
-                    // location.reload(true);
+                    location.reload(true);
                 }
             })
           })
@@ -100,7 +100,7 @@ $(document).ready(function() {
               },
               success: function(data) {
                   destination_square.empty();
-                  // location.reload(true);
+                  location.reload(true);
               }
           });
         }

--- a/app/controllers/chess_pieces_controller.rb
+++ b/app/controllers/chess_pieces_controller.rb
@@ -7,7 +7,7 @@ class ChessPiecesController < ApplicationController
 
     @chess_piece.update(chess_piece_params) if @chess_piece.move_to!([params[:x_position], params[:y_position]])
 
-    #@chess_piece.update(chess_piece_params) if @chess_piece.pawn_promotion([params[:x_position], params[:y_position]])
+    # @chess_piece.update(chess_piece_params) if @chess_piece.pawn_promotion([params[:x_position], params[:y_position]])
 
     respond_to do |format|
       format.html { render :show }

--- a/app/controllers/chess_pieces_controller.rb
+++ b/app/controllers/chess_pieces_controller.rb
@@ -7,6 +7,8 @@ class ChessPiecesController < ApplicationController
 
     @chess_piece.update(chess_piece_params) if @chess_piece.move_to!([params[:x_position], params[:y_position]])
 
+    #@chess_piece.update(chess_piece_params) if @chess_piece.pawn_promotion([params[:x_position], params[:y_position]])
+
     respond_to do |format|
       format.html { render :show }
       format.json { render json: @chess_piece, status: :ok }

--- a/app/models/chess_piece.rb
+++ b/app/models/chess_piece.rb
@@ -68,10 +68,10 @@ class ChessPiece < ApplicationRecord
     end
     false
   end
-  
+
   def not_at_destination
     @x_move.send(@x_dir.positive? ? '<' : '>', @x2) ||
-    @y_move.send(@y_dir.positive? ? '<' : '>', @y2)
+      @y_move.send(@y_dir.positive? ? '<' : '>', @y2)
   end
 
   def selected(piece, chess_piece)

--- a/app/models/chess_piece.rb
+++ b/app/models/chess_piece.rb
@@ -68,7 +68,7 @@ class ChessPiece < ApplicationRecord
     end
     false
   end
-
+  
   def not_at_destination
     @x_move.send(@x_dir.positive? ? '<' : '>', @x2) ||
     @y_move.send(@y_dir.positive? ? '<' : '>', @y2)

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -31,5 +31,4 @@ class Pawn < ChessPiece
     @can_capture = true if is_obstructed?([x2, y2]) && slope.abs == 1
     true
   end
-
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -31,4 +31,5 @@ class Pawn < ChessPiece
     @can_capture = true if is_obstructed?([x2, y2]) && slope.abs == 1
     true
   end
+
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -41,9 +41,11 @@
                     <% y = piece.y_position %>
                     <% htmlcode = piece.htmlcode %>
                     <% if x == col && y == row %>
-                    <div class="piece" data-x-coord=<%=col%> data-y-coord=
-                        <%= row %> data-piece-id=
-                        <%=piece.id%>
+                    <div class="piece" 
+                        data-x-coord=<%=col%> 
+                        data-y-coord=<%=row%> 
+                        data-piece-id=<%=piece.id%> 
+                        data-piece-type=<%=piece.type%>
                         >
                         <%=  piece.htmlcode.html_safe  %>
                     </div>
@@ -67,7 +69,7 @@
         <br/>
         <br/>
     <% end %>
-    <!-- Button trigger modal -->
+    <!--  Forfeit Button trigger modal -->
     <button type="button" class="btn btn-danger btn-lg" data-toggle="modal" data-target="#forfeitModal">
       Forfeit Game
     </button>
@@ -76,50 +78,28 @@
     <br/>
   </div>
 </div>
+<!-- end of Forfeit Model -->
 
-<script>
-$(document).ready($(function() {
-    $('.piece').draggable({
-        snap: '.droppable',
-        revert: 'invalid'
-    });
+<!-- Trigger/Open The Modal -->
+<button id="myBtn">Open Modal</button>
 
-    $('.droppable').droppable({
-        drop: function(event, ui) {
-            let piece = ui.draggable
-            let destination_square = $(this);
-            console.log($(this));
-            var update_piece = {
-                id: piece.data('piece-id'),
-                game_id: piece.data('game-id'),
-                x_position: destination_square.data('x_position'),
-                y_position: destination_square.data('y_position')
+<!-- The Modal -->
+<div id="pawnPromoteModal" class="modal">
 
-
-            }
-
-
-
-
-            $.ajax({
-                type: 'PATCH',
-                url: '/chess_pieces/' + update_piece.id,
-                beforeSend: function(xhr) { xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content')) },
-                dataType: 'json',
-                data: {
-                    id: update_piece.id,
-                    game_id: update_piece.game_id,
-                    x_position: update_piece.x_position,
-                    y_position: update_piece.y_position
-                },
-                success: function(data) {
-                    destination_square.empty();
-                    location.reload(true);
-                }
-            });
-
-        }
-    });
-
-}));
-</script>
+  <!-- Modal content -->
+  <div class="modal-content">
+    <span class="close">&times;</span>
+        <div id="queenSelection" class="promoteBtns">
+            <button id="queenBtn">Queen</button>
+        </div>
+        <div id="bishopSelection" class="promoteBtns">
+            <button id="bishopBtn">Bishop</button>
+        </div>
+        <div id="rookSelection" class="promoteBtns">
+            <button id="rookBtn">Rook</button>
+        </div>
+        <div id="knightSelection" class="promoteBtns">
+            <button id="knightBtn">Knight</button>
+        </div>
+  </div>
+</div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -82,7 +82,7 @@
 <!-- end of Forfeit Model -->
 
 <!-- Trigger/Open The Modal -->
-<button id="myBtn">Open Modal</button>
+<button id="myBtn"></button>
 
 <!-- The Modal -->
 <div id="pawnPromoteModal" class="modal">

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -46,6 +46,7 @@
                         data-y-coord=<%=row%> 
                         data-piece-id=<%=piece.id%> 
                         data-piece-type=<%=piece.type%>
+                        data-color=<%=piece.color%>
                         >
                         <%=  piece.htmlcode.html_safe  %>
                     </div>
@@ -87,19 +88,19 @@
 <div id="pawnPromoteModal" class="modal">
 
   <!-- Modal content -->
-  <div class="modal-content">
+  <div id="promote_container" class="modal-content">
     <span class="close">&times;</span>
         <div id="queenSelection" class="promoteBtns">
-            <button id="queenBtn">Queen</button>
+            <button id="queenBtn" value="Queen" htmlcode="&#9813;">Queen</button>
         </div>
         <div id="bishopSelection" class="promoteBtns">
-            <button id="bishopBtn">Bishop</button>
+            <button id="bishopBtn" value="Bishop" htmlcode="&#9815;" >Bishop</button>
         </div>
         <div id="rookSelection" class="promoteBtns">
-            <button id="rookBtn">Rook</button>
+            <button id="rookBtn" value="Rook" htmlcode="&#9814;">Rook</button>
         </div>
         <div id="knightSelection" class="promoteBtns">
-            <button id="knightBtn">Knight</button>
+            <button id="knightBtn" value="Knight" htmlcode="&#9816;">Knight</button>
         </div>
   </div>
 </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,7 +19,6 @@ ActiveRecord::Schema.define(version: 20_191_204_031_457) do
     t.datetime 'updated_at', null: false
   end
 
-
   create_table 'chess_pieces', force: :cascade do |t|
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
@@ -74,18 +73,17 @@ ActiveRecord::Schema.define(version: 20_191_204_031_457) do
     t.datetime 'updated_at', null: false
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "provider"
-    t.string "uid"
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  create_table 'users', force: :cascade do |t|
+    t.string 'email', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.datetime 'remember_created_at'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.string 'provider'
+    t.string 'uid'
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
   end
-
 end


### PR DESCRIPTION
# Trello Ticket: 
https://trello.com/c/T34prnWj/46-pawn-promotion

# Description:
Add the ability for a pawn to be promoted into any of the following types. You will need to think through how to prompt the user for what piece they want to take (queen, knight, or if they’re in a case where doing so would cause a stalemate a rook or bishop)

# Documentation Referenced:
none